### PR TITLE
Feature/non empty text factory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": "^7.0",
         "psr/http-message": "^1.0",
-        "beberlei/assert": "^2.5"
+        "beberlei/assert": "^2.6"
     },
     "require-dev": {
         "ext-iconv": "*",

--- a/doc/src/mappings.md
+++ b/doc/src/mappings.md
@@ -89,6 +89,10 @@ mappings:
 `text(int $minLength = 0, int $maxLength = null, string $encoding = 'utf-8')`
 :   Creates a simple string-to-string mapping, optionally applying constraints for the length of the string.
 
+`nonEmptyText(int $maxLength = null, string $encoding = 'utf-8')`
+:   Creates a simple string-to-string mapping which requires the input to be a non-empty string, optionally applying
+    constraints for the max length of the string.
+
 `emailAddress()`
 :   Creates a mapping which requires the input string to be a valid email address.
 

--- a/src/Helper/ErrorFormatter.php
+++ b/src/Helper/ErrorFormatter.php
@@ -11,6 +11,7 @@ final class ErrorFormatter
 {
     const BUILD_IN_MESSAGES = [
         'error.required' => 'This field is required',
+        'error.empty' => 'Value must not be empty',
         'error.integer' => 'Integer value expected',
         'error.float' => 'Float value expected',
         'error.boolean' => 'Boolean value expected',

--- a/src/Mapping/Constraint/ChainConstraint.php
+++ b/src/Mapping/Constraint/ChainConstraint.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types = 1);
+
+namespace DASPRiD\Formidable\Mapping\Constraint;
+
+class ChainConstraint implements ConstraintInterface
+{
+    /**
+     * @var bool
+     */
+    private $breakChainOnFailure;
+
+    /**
+     * @var ConstraintInterface[]
+     */
+    private $constraints;
+
+    public function __construct(bool $breakChainOnFailure, ConstraintInterface ...$constraints)
+    {
+        $this->breakChainOnFailure = $breakChainOnFailure;
+        $this->constraints = $constraints;
+    }
+
+    public function __invoke($value) : ValidationResult
+    {
+        $validationResult = new ValidationResult();
+
+        foreach ($this->constraints as $constraint) {
+            $childValidationResult = $constraint($value);
+
+            if ($childValidationResult->isSuccess()) {
+                continue;
+            }
+
+            if ($this->breakChainOnFailure) {
+                return $childValidationResult;
+            }
+
+            $validationResult = $validationResult->merge($childValidationResult);
+        }
+
+        return $validationResult;
+    }
+}

--- a/src/Mapping/Constraint/NotEmptyConstraint.php
+++ b/src/Mapping/Constraint/NotEmptyConstraint.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types = 1);
+
+namespace DASPRiD\Formidable\Mapping\Constraint;
+
+use Assert\Assertion;
+
+class NotEmptyConstraint implements ConstraintInterface
+{
+    public function __invoke($value) : ValidationResult
+    {
+        Assertion::string($value);
+
+        if ('' === $value) {
+            return new ValidationResult(new ValidationError('error.empty'));
+        }
+
+        return new ValidationResult();
+    }
+}

--- a/test/Helper/ErrorFormatterTest.php
+++ b/test/Helper/ErrorFormatterTest.php
@@ -27,6 +27,7 @@ class ErrorFormatterTest extends TestCase
     {
         return [
             'error.required' => ['error.required', 'This field is required'],
+            'error.empty' => ['error.empty', 'Value must not be empty'],
             'error.integer' => ['error.integer', 'Integer value expected'],
             'error.float' => ['error.float', 'Float value expected'],
             'error.boolean' => ['error.boolean', 'Boolean value expected'],

--- a/test/Mapping/Constraint/ChainConstraintTest.php
+++ b/test/Mapping/Constraint/ChainConstraintTest.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types = 1);
+
+namespace DASPRiD\FormidableTest\Mapping\Constraint;
+
+use DASPRiD\Formidable\Mapping\Constraint\ChainConstraint;
+use DASPRiD\Formidable\Mapping\Constraint\ConstraintInterface;
+use DASPRiD\Formidable\Mapping\Constraint\ValidationError;
+use DASPRiD\Formidable\Mapping\Constraint\ValidationResult;
+use PHPUnit_Framework_TestCase as TestCase;
+
+/**
+ * @covers DASPRiD\Formidable\Mapping\Constraint\ChainConstraint
+ */
+class ChainConstraintTest extends TestCase
+{
+    public function testSuccessfulChain()
+    {
+        $constraintA = $this->prophesize(ConstraintInterface::class);
+        $constraintA->__invoke('a')->willReturn(new ValidationResult());
+
+        $constraintB = $this->prophesize(ConstraintInterface::class);
+        $constraintB->__invoke('a')->willReturn(new ValidationResult());
+
+        $constraint = new ChainConstraint(true, $constraintA->reveal(), $constraintB->reveal());
+        $validationResult = $constraint('a');
+        $this->assertTrue($validationResult->isSuccess());
+    }
+
+    public function testBreakingChain()
+    {
+        $constraintA = $this->prophesize(ConstraintInterface::class);
+        $constraintA->__invoke('a')->willReturn(new ValidationResult(new ValidationError('a')));
+
+        $constraintB = $this->prophesize(ConstraintInterface::class);
+        $constraintB->__invoke('a')->willReturn(new ValidationResult(new ValidationError('b')));
+
+        $constraint = new ChainConstraint(true, $constraintA->reveal(), $constraintB->reveal());
+        $validationResult = $constraint('a');
+        $this->assertFalse($validationResult->isSuccess());
+        ValidationErrorAssertion::assertErrorMessages(
+            $this,
+            $validationResult,
+            ['a' => []]
+        );
+    }
+
+    public function testNonBreakingChainWithMultipleFailures()
+    {
+        $constraintA = $this->prophesize(ConstraintInterface::class);
+        $constraintA->__invoke('a')->willReturn(new ValidationResult(new ValidationError('a')));
+
+        $constraintB = $this->prophesize(ConstraintInterface::class);
+        $constraintB->__invoke('a')->willReturn(new ValidationResult(new ValidationError('b')));
+
+        $constraint = new ChainConstraint(false, $constraintA->reveal(), $constraintB->reveal());
+        $validationResult = $constraint('a');
+        $this->assertFalse($validationResult->isSuccess());
+        ValidationErrorAssertion::assertErrorMessages(
+            $this,
+            $validationResult,
+            ['a' => [], 'b' => []]
+        );
+    }
+
+    public function testNonBreakingChainWithLastFailure()
+    {
+        $constraintA = $this->prophesize(ConstraintInterface::class);
+        $constraintA->__invoke('a')->willReturn(new ValidationResult());
+
+        $constraintB = $this->prophesize(ConstraintInterface::class);
+        $constraintB->__invoke('a')->willReturn(new ValidationResult(new ValidationError('b')));
+
+        $constraint = new ChainConstraint(false, $constraintA->reveal(), $constraintB->reveal());
+        $validationResult = $constraint('a');
+        $this->assertFalse($validationResult->isSuccess());
+        ValidationErrorAssertion::assertErrorMessages(
+            $this,
+            $validationResult,
+            ['b' => []]
+        );
+    }
+}

--- a/test/Mapping/Constraint/NotEmptyConstraintTest.php
+++ b/test/Mapping/Constraint/NotEmptyConstraintTest.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types = 1);
+
+namespace DASPRiD\FormidableTest\Mapping\Constraint;
+
+use Assert\AssertionFailedException;
+use DASPRiD\Formidable\Mapping\Constraint\NotEmptyConstraint;
+use PHPUnit_Framework_TestCase as TestCase;
+
+/**
+ * @covers DASPRiD\Formidable\Mapping\Constraint\NotEmptyConstraint
+ */
+class NotEmptyConstraintTest extends TestCase
+{
+    public function testAssertionWithInvalidValueType()
+    {
+        $constraint = new NotEmptyConstraint();
+        $this->expectException(AssertionFailedException::class);
+        $constraint(1);
+    }
+
+    public function testFailureWithEmptyString()
+    {
+        $constraint = new NotEmptyConstraint();
+        $validationResult = $constraint('');
+        $this->assertFalse($validationResult->isSuccess());
+        ValidationErrorAssertion::assertErrorMessages(
+            $this,
+            $validationResult,
+            ['error.empty' => []]
+        );
+    }
+
+    public function testSuccessWithValidString()
+    {
+        $constraint = new NotEmptyConstraint();
+        $validationResult = $constraint('a');
+        $this->assertTrue($validationResult->isSuccess());
+    }
+}

--- a/test/Mapping/FieldMappingFactoryTest.php
+++ b/test/Mapping/FieldMappingFactoryTest.php
@@ -3,7 +3,9 @@ declare(strict_types = 1);
 
 namespace DASPRiD\FormidableTest\Mapping;
 
+use DASPRiD\Formidable\Mapping\Constraint\ChainConstraint;
 use DASPRiD\Formidable\Mapping\Constraint\EmailAddressConstraint;
+use DASPRiD\Formidable\Mapping\Constraint\NotEmptyConstraint;
 use DASPRiD\Formidable\Mapping\Constraint\UrlConstraint;
 use DASPRiD\Formidable\Mapping\FieldMapping;
 use DASPRiD\Formidable\Mapping\FieldMappingFactory;
@@ -45,6 +47,43 @@ class FieldMappingFactoryTest extends TestCase
 
         $this->assertAttributeSame('iso-8859-15', 'encoding', $constraints[1]);
         $this->assertAttributeSame(2, 'lengthLimit', $constraints[1]);
+    }
+
+    public function testNonEmptyTextFactoryWithoutConstraints()
+    {
+        $fieldMapping = FieldMappingFactory::nonEmptyText();
+        $this->assertInstanceOf(FieldMapping::class, $fieldMapping);
+        $this->assertAttributeInstanceOf(TextFormatter::class, 'binder', $fieldMapping);
+        $this->assertAttributeCount(1, 'constraints', $fieldMapping);
+
+        $constraints = self::readAttribute($fieldMapping, 'constraints');
+        $this->assertInstanceOf(ChainConstraint::class, $constraints[0]);
+        $this->assertAttributeSame(true, 'breakChainOnFailure', $constraints[0]);
+        $this->assertAttributeCount(1, 'constraints', $constraints[0]);
+
+        $chainConstraints = self::readAttribute($constraints[0], 'constraints');
+
+        $this->assertInstanceOf(NotEmptyConstraint::class, $chainConstraints[0]);
+    }
+
+    public function testNonEmptyTextFactoryWithConstraints()
+    {
+        $fieldMapping = FieldMappingFactory::nonEmptyText(2, 'iso-8859-15');
+        $this->assertInstanceOf(FieldMapping::class, $fieldMapping);
+        $this->assertAttributeInstanceOf(TextFormatter::class, 'binder', $fieldMapping);
+        $this->assertAttributeCount(1, 'constraints', $fieldMapping);
+
+        $constraints = self::readAttribute($fieldMapping, 'constraints');
+        $this->assertInstanceOf(ChainConstraint::class, $constraints[0]);
+        $this->assertAttributeSame(true, 'breakChainOnFailure', $constraints[0]);
+        $this->assertAttributeCount(2, 'constraints', $constraints[0]);
+
+        $chainConstraints = self::readAttribute($constraints[0], 'constraints');
+
+        $this->assertInstanceOf(NotEmptyConstraint::class, $chainConstraints[0]);
+
+        $this->assertAttributeSame('iso-8859-15', 'encoding', $chainConstraints[1]);
+        $this->assertAttributeSame(2, 'lengthLimit', $chainConstraints[1]);
     }
 
     public function testEmailAddressFactory()


### PR DESCRIPTION
This PR adds the a new method in the `FieldMappingFactory`, namely `nonEmptyText()`. This creates an input similar to the `text()` factory method, but always requires the input to be a non-empty text, otherwise it emits a `error.empty` message.

Since the sole purpose of this input is to be non-empty, no additional `minLength` constraint is applied. A `maxLength` constraint can still be applied through the method though.